### PR TITLE
Prevent Other Bookmarks from overlapping with bar.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 build.zip
+.sass-cache

--- a/stylesheets/bookmark.sass
+++ b/stylesheets/bookmark.sass
@@ -58,7 +58,7 @@
 
   .bookmarks-list
     padding-left: 5px
-    padding-right: 0px
+    padding-right: 125px
 
     &.other-bookmarks
       position: absolute


### PR DESCRIPTION
Adds some right padding to bookmarks bar so there is room for 'Other
Bookmarks' link.

![screenshot_2015-01-25_22 54 38](https://cloud.githubusercontent.com/assets/3153035/6095618/76852d64-af19-11e4-8bdc-7b1b5bf9d27b.png)
